### PR TITLE
Network and environment variable configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ Compile contracts via Hardhat:
 yarn run hardhat compile
 ```
 
+The Hardhat environment relies on the following environment variables. The `dotenv` package will attempt to read them from the `.env` and `.env.secret` files, if they are present.
+
+| Key                | Description                                                   |
+| ------------------ | ------------------------------------------------------------- |
+| `NODE_URL_MAINNET` | JSON-RPC node URL for `mainnet` network                       |
+| `NODE_URL_TESTNET` | JSON-RPC node URL for `testnet` network                       |
+| `PKEY_TESTNET`     | private key for test/development use on `testnet` network     |
+| `PKEY_MAINNET`     | private key for production use on `mainnet` network           |
+| `REPORT_GAS`       | if `true`, a gas report will be generated after running tests |
+
 ### Networks
 
 By default, Hardhat uses the Hardhat Network in-process. Two additional networks, `mainnet` and `testnet` are available, and their behavior is determined by the configuration of environment variables.

--- a/README.md
+++ b/README.md
@@ -26,13 +26,7 @@ yarn run hardhat compile
 
 ### Networks
 
-By default, Hardhat uses the Hardhat Network in-process.
-
-To use an external network via URL, set the `NODE_URL` environment variable and append commands with `--network generic`:
-
-```bash
-NODE_URL="[NODE_URL]" yarn run hardhat test --network generic
-```
+By default, Hardhat uses the Hardhat Network in-process. Two additional networks, `mainnet` and `testnet` are available, and their behavior is determined by the configuration of environment variables.
 
 ### Testing
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -9,6 +9,14 @@ import Dotenv from 'dotenv';
 
 Dotenv.config();
 
+const {
+  NODE_URL_MAINNET,
+  NODE_URL_TESTNET,
+  PKEY_MAINNET,
+  PKEY_TESTNET,
+  REPORT_GAS,
+} = process.env;
+
 export default {
   solidity: {
     version: '0.8.11',
@@ -22,13 +30,13 @@ export default {
 
   networks: {
     mainnet: {
-      url: `${process.env.NODE_URL_MAINNET}`,
-      accounts: [`${process.env.PKEY_MAINNET}`],
+      url: NODE_URL_MAINNET,
+      accounts: [PKEY_MAINNET],
     },
 
     testnet: {
-      url: `${process.env.NODE_URL_TESTNET}`,
-      accounts: [`${process.env.PKEY_TESTNET}`],
+      url: NODE_URL_TESTNET,
+      accounts: [PKEY_TESTNET],
     },
   },
 
@@ -38,7 +46,7 @@ export default {
   },
 
   gasReporter: {
-    enabled: process.env.REPORT_GAS === 'true',
+    enabled: REPORT_GAS === 'true',
   },
 
   spdxLicenseIdentifier: {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -21,11 +21,14 @@ export default {
   },
 
   networks: {
-    generic: {
-      url: `${process.env.NODE_URL}`,
-      accounts: {
-        mnemonic: `${process.env.MNEMONIC}`,
-      },
+    mainnet: {
+      url: `${process.env.NODE_URL_MAINNET}`,
+      accounts: [`${process.env.PKEY_MAINNET}`],
+    },
+
+    testnet: {
+      url: `${process.env.NODE_URL_TESTNET}`,
+      accounts: [`${process.env.PKEY_TESTNET}`],
     },
   },
 


### PR DESCRIPTION
Simplified network configuration to use generic `mainnet` and `testnet`, documented use of dotenv to set related environment variables.